### PR TITLE
FIX: runId issue when both existingPlanId and runId are set in the co…

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,13 @@ module.exports = (config) => {
 					};
 
 					const res = await testrail.addPlanEntry(config.plan.existingPlanId, data);
-					runId = res.runs[0].id;
+
+					if (config.runId) {
+						runId = config.runId;
+					} else {
+						runId = res.runs[0].id;
+					}
+
 				} else {
 					const data = {
 						description: config.plan.description || '',

--- a/index.js
+++ b/index.js
@@ -269,13 +269,7 @@ module.exports = (config) => {
 					};
 
 					const res = await testrail.addPlanEntry(config.plan.existingPlanId, data);
-
-					if (config.runId) {
-						runId = config.runId;
-					} else {
-						runId = res.runs[0].id;
-					}
-
+					runId = config.runId ? config.runId : res.runs[0].id;
 				} else {
 					const data = {
 						description: config.plan.description || '',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-testrail",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "CodeceptJS plugin for TestRail",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The condition tree does not take into account the presence of the `runId`, if `plan.existingPlanId` already set.
This new code in the tree condition fix the situation when both `existingPlanId` and `runId` is seted in the config.
