### PR TITLE
Feat/#24 support cucumber scenario outline

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,6 +183,14 @@ module.exports = (config) => {
 	}
 
 	event.dispatcher.on(event.test.started, async (test) => {
+		if (test.body) {
+			if (test.body.includes('addExampleInTable')) {
+				const testRailTag = /"testRailTag":"(@C\d+)"/.exec(test.title);
+				if (testRailTag) {
+					test.tags.push(testRailTag[1]);
+				}
+			}
+		}
 		test.startTime = Date.now();
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-testrail",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "CodeceptJS plugin for TestRail",
   "main": "index.js",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,19 @@ A Gherkin example:
     Then I see search textbox
     And I see search button
 ```
+**Note:**
+TestRail tag in **Examples** from **Scenario Outline** available from version `1.7.4` and above
+```gherkin
+  @someTag
+  Scenario Outline: Fill some field
+    When I fill some field by text <text>
+    Then I see text <text>
+    
+    Examples:
+      | testRailTag | text      |
+      | @C1234      | someText1 |
+      | @C1235      | someText2 |
+```
 
 ##### Configuration
 


### PR DESCRIPTION
According to Scenario Outline implementation in the CodeceptJS(  [gherkin.js](https://github.com/codeceptjs/CodeceptJS/blob/3.x/lib/interfaces/gherkin.js) ) I've implemented getting a TestRail tag from Examples and adding the `testRailTag` to the test tags. 