### PR TITLE
Better add to case template

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ class TestRail {
 			output.log(`The response is ${JSON.stringify(res.data)}`);
 			return res.data;
 		}).catch(error => {
-			output.error(`Cannot add result for case due to ${error}`);
+			output.error(`Cannot add result for case due to ${error.response.data.error}`);
 		});
 	}
 

--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ class TestRail {
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
 			output.error(`Cannot update run due to ${parsedError}`);
+			output.error(`Request data was: ${JSON.stringify(data)}`);
 		}
 	}
 
@@ -125,6 +126,7 @@ class TestRail {
 		}).catch(error => {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
 			output.error(`Cannot add result for case due to ${parsedError}`);
+			output.error(`Request data was: ${JSON.stringify(data)}`);
 		});
 	}
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,8 @@ class TestRail {
 			output.log(`The response is ${JSON.stringify(res.data)}`);
 			return res.data;
 		}).catch(error => {
-			output.error(`Cannot add result for case due to ${error.response.data.error}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`Cannot add result for case due to ${parsedError}`);
 		});
 	}
 

--- a/index.js
+++ b/index.js
@@ -103,7 +103,8 @@ class TestRail {
 			output.log(`The run with id: ${runId} is updated`);
 			return res.data;
 		} catch (error) {
-			output.error(`Cannot update run due to ${error}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`Cannot update run due to ${parsedError}`);
 		}
 	}
 


### PR DESCRIPTION
Changes:
---
- [ ] remove all non-existent case labels from the `addResultsForCases` call to not fail the POST XHR call

With this change in:
---
```
Error: some labels are missing from the test run and the results were not send through: ["3478610"]
node_modules/codeceptjs-testrail/lib/output.js:26
```

Bugs:
--- 
Part of https://github.com/PeterNgTr/codeceptjs-testrail/issues/42