### PR TITLE
Better POSTS for cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,10 +360,12 @@ module.exports = (config) => {
 			// Before POST-ing the results, filter the array for any non-existing tags in TR
 			let validResults = [];
 			testrail.getCases(config.projectId, config.suiteId).then(res => {
-				validResults = allResults.filter(result => res.find(tag => tag.id == result.case_id))
-				const missingLabels = allResults.filter(result => !validResults.find(vResult => vResult.case_id == result.case_id));
-				if (missingLabels.length) {
-					output.error(`Error: some labels are missing from the test run and the results were not send through: ${JSON.stringify(missingLabels.map(l => l.case_id))}`);
+				if (res.length) {
+					validResults = allResults.filter(result => res.find(tag => tag.id == result.case_id))
+					const missingLabels = allResults.filter(result => !validResults.find(vResult => vResult.case_id == result.case_id));
+					if (missingLabels.length) {
+						output.error(`Error: some labels are missing from the test run and the results were not send through: ${JSON.stringify(missingLabels.map(l => l.case_id))}`);
+					}
 				}
 			}).then(() => {
 				if (!!validResults.length) {

--- a/test/db.json
+++ b/test/db.json
@@ -3,6 +3,6 @@
   "add_run": [],
   "update_run": [],
   "add_results_for_cases": [],
-  "get_cases": [{"id": "1"}],
+  "get_cases": [{"id": "1"}, {"id": "2"}],
   "get_results_for_case": []
 }

--- a/test/db.json
+++ b/test/db.json
@@ -3,5 +3,6 @@
   "add_run": [],
   "update_run": [],
   "add_results_for_cases": [],
+  "get_cases": [{"id": "1"}],
   "get_results_for_case": []
 }

--- a/test/routes.json
+++ b/test/routes.json
@@ -5,6 +5,7 @@
   "/index.php?/api/v2/update_run/2": "/update_run/",
   "/index.php?/api/v2/add_results_for_cases/1": "/add_results_for_cases/",
   "/index.php?/api/v2/add_results_for_cases/2": "/add_results_for_cases/",
+  "/index.php?/api/v2/get_cases/1&suite_id=1": "/get_cases/",
   "/index.php?/api/v2/get_results_for_case/1/2": "/get_results_for_case/",
   "/index.php?/api/v2/get_results_for_case/2/2": "/get_results_for_case/"
 }


### PR DESCRIPTION
Changes:
---
- [x] remove all non-existent case labels from the `addResultsForCases` call to not fail the POST XHR call

With this change in:
---
```
Error: some labels are missing from the test run and the results were not send through: ["3478610"]
node_modules/codeceptjs-testrail/lib/output.js:26
```

Bugs:
--- 
Part of https://github.com/PeterNgTr/codeceptjs-testrail/issues/42