### PR TITLE
More logs - uniform accross the helpers set

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,88 +55,115 @@ class TestRail {
 	async getCases(projectId, suiteId) {
 		try {
 			const res = await this.axios.get(`get_cases/${projectId}&suite_id=${suiteId}`);
+			output.log(`getCases: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`getCases: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`Cannot get cases for projectId:${projectId} & suiteId:${suiteId}, due to ${parsedError}`);
+			output.error(`getCases: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`getCases: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
 	async addPlan(projectId, data) {
 		try {
 			const res = await this.axios.post('add_plan/' + projectId, data);
+			output.log(`addPlan: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`addPlan: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
-			output.error(`Cannot add new plan due to ${error}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`addPlan: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`addPlan: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
 	async addPlanEntry(planId, data) {
 		try {
 			const res = await this.axios.post('add_plan_entry/' + planId, data);
+			output.log(`addPlanEntry: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`addPlanEntry: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
-			output.error(`Cannot add new test run to existing test plan due to ${error}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`addPlanEntry: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`addPlanEntry: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
 	async getSuites(projectId) {
 		try {
 			const res = await this.axios.get('get_suites/' + projectId);
+			output.log(`getSuites: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`getSuites: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
-			output.error(`Cannot get suites due to ${error}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`getSuites: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`getSuites: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
 	async getConfigs(projectId) {
 		try {
 			const res = await this.axios.get('get_configs/' + projectId);
+			output.log(`getConfigs: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`getConfigs: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
-			output.error(`Cannot get configs due to ${error}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`getConfigs: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`getConfigs: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
 	async addRun(projectId, data) {
 		try {
 			const res = await this.axios.post('add_run/' + projectId, data);
+			output.log(`addRun: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`addRun: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
-			output.error(`Cannot add new run due to ${error}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`addRun: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`addRun: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
 	async updateRun(runId, data) {
 		try {
 			const res = await this.axios.post('update_run/' + runId, data);
-			output.log(`The run with id: ${runId} is updated`);
+			output.log(`updateRun: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`updateRun: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`Cannot update run due to ${parsedError}`);
-			output.error(`Request data was: ${JSON.stringify(data)}`);
+			output.error(`updateRun: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`updateRun: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
 	async getResultsForCase(runId, caseId) {
 		return this.axios.get(`get_results_for_case/${runId}/${caseId}`).then((res) => {
-			output.log(`The response is ${JSON.stringify(res.data)}`);
-			output.log(`The case ${caseId} on run ${runId} is updated`);
+			output.log(`getResultsForCase: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`getResultsForCase: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		}).catch(error => {
-			output.error(`Cannot get results for case ${caseId} on run ${runId} due to ${error}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`getResultsForCase: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`getResultsForCase: ERROR - request data was ${JSON.stringify(data)}`);
 		});
 	}
 
 	async addResultsForCases(runId, data) {
 		return this.axios.post('add_results_for_cases/' + runId, data).then((res) => {
-			output.log(`The response is ${JSON.stringify(res.data)}`);
+			output.log(`addResultsForCases: SUCCESS - the request data is ${JSON.stringify(data)}`);
+			output.log(`addResultsForCases: SUCCESS - response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		}).catch(error => {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`Cannot add result for case due to ${parsedError}`);
-			output.error(`Request data was: ${JSON.stringify(data)}`);
+			output.error(`addResultsForCases: ERROR - cannot add result for case due to ${parsedError}`);
+			output.error(`addResultsForCases: ERROR - request data was ${JSON.stringify(data)}`);
 		});
 	}
 
@@ -150,7 +177,9 @@ class TestRail {
 			url: 'add_attachment_to_result/' + resultId,
 			headers: form.getHeaders()
 		}).catch(err => {
-			output.error(`Cannot attach file due to ${err}`);
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`addAttachmentToResult: ERROR - cannot add attachment due to ${parsedError}`);
+			output.error(`addAttachmentToResult: ERROR - request data was ${JSON.stringify(data)}`);
 		});
 	}
 }

--- a/lib/testrail.js
+++ b/lib/testrail.js
@@ -23,13 +23,11 @@ class TestRail {
 	async getCases(projectId, suiteId) {
 		try {
 			const res = await this.axios.get(`get_cases/${projectId}&suite_id=${suiteId}`);
-			output.log(`getCases: SUCCESS - the request data is ${JSON.stringify(data)}`);
 			output.log(`getCases: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
 			output.error(`getCases: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
-			output.error(`getCases: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
@@ -41,7 +39,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`addPlan: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`addPlan: ERROR - cannot get results runId:${runId} due to ${parsedError}`);
 			output.error(`addPlan: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
@@ -54,7 +52,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`addPlanEntry: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`addPlanEntry: ERROR - cannot get results on planId:${planId} due to ${parsedError}`);
 			output.error(`addPlanEntry: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
@@ -62,26 +60,22 @@ class TestRail {
 	async getSuites(projectId) {
 		try {
 			const res = await this.axios.get('get_suites/' + projectId);
-			output.log(`getSuites: SUCCESS - the request data is ${JSON.stringify(data)}`);
 			output.log(`getSuites: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`getSuites: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
-			output.error(`getSuites: ERROR - request data was ${JSON.stringify(data)}`);
+			output.error(`getSuites: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);
 		}
 	}
 
 	async getConfigs(projectId) {
 		try {
 			const res = await this.axios.get('get_configs/' + projectId);
-			output.log(`getConfigs: SUCCESS - the request data is ${JSON.stringify(data)}`);
 			output.log(`getConfigs: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`getConfigs: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
-			output.error(`getConfigs: ERROR - request data was ${JSON.stringify(data)}`);
+			output.error(`getConfigs: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);
 		}
 	}
 
@@ -93,7 +87,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`addRun: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`addRun: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);
 			output.error(`addRun: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
@@ -106,20 +100,18 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`updateRun: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`updateRun: ERROR - cannot get results for runId:${runId} due to ${parsedError}`);
 			output.error(`updateRun: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
 
 	async getResultsForCase(runId, caseId) {
 		return this.axios.get(`get_results_for_case/${runId}/${caseId}`).then((res) => {
-			output.log(`getResultsForCase: SUCCESS - the request data is ${JSON.stringify(data)}`);
 			output.log(`getResultsForCase: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
 			return res.data;
 		}).catch(error => {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`getResultsForCase: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
-			output.error(`getResultsForCase: ERROR - request data was ${JSON.stringify(data)}`);
+			output.error(`getResultsForCase: ERROR - cannot get results for caseId:${caseId} on runId:${runId} due to ${parsedError}`);
 		});
 	}
 
@@ -139,7 +131,7 @@ class TestRail {
 		let form = new FormData();
 		form.append('attachment', fs.createReadStream(path.join(global.output_dir, imageFile.toString())));
 
-		this.axios({
+		await this.axios({
 			method: 'post',
 			data: form,
 			url: 'add_attachment_to_result/' + resultId,
@@ -147,7 +139,7 @@ class TestRail {
 		}).catch(err => {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
 			output.error(`addAttachmentToResult: ERROR - cannot add attachment due to ${parsedError}`);
-			output.error(`addAttachmentToResult: ERROR - request data was ${JSON.stringify(data)}`);
+			output.error(`addAttachmentToResult: ERROR - request data was ${JSON.stringify(form)}`);
 		});
 	}
 }

--- a/lib/testrail.js
+++ b/lib/testrail.js
@@ -27,7 +27,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`getCases: ERROR - cannot get results for case ${caseId} on run ${runId} due to ${parsedError}`);
+			output.error(`getCases: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);
 		}
 	}
 
@@ -39,7 +39,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`addPlan: ERROR - cannot get results runId:${runId} due to ${parsedError}`);
+			output.error(`addPlan: ERROR - cannot get results projectId:${projectId} due to ${parsedError}`);
 			output.error(`addPlan: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}

--- a/test/acceptance_test.js
+++ b/test/acceptance_test.js
@@ -79,9 +79,8 @@ describe('Valid config file', () => {
 	describe('Add run and test result', () => {
 		it('should update the results on passed case', (done) => {
 			exec(`${runner} --grep @pass -c ${mockTestrailConfig}`, (err, stdout) => {
-				expect(stdout).to.include('The run with id: 1 is updated');
-				expect(stdout).to.include('The run 1 is updated with');
-				expect(stdout).to.include('"status_id":1');
+				expect(stdout).to.include('addRun: SUCCESS - the request data is {"suite_id":1,"name":"Custom run name","include_all":false}');
+				expect(stdout).to.include('addRun: SUCCESS - the response data is {"suite_id":1,"name":"Custom run name","include_all":false,"id":1}');
 				done();
 			});
 		});
@@ -89,8 +88,8 @@ describe('Valid config file', () => {
 		it('should update the results on failed case', (done) => {
 			exec(`${runner} --grep @fail -c ${mockTestrailConfig}`, (err, stdout) => {
 				expect(stdout).to.include('FAIL  | 0 passed, 1 failed');
-				expect(stdout).to.include('The case 2 on run 2 is updated');
-				expect(stdout).to.include('"status_id":5');
+				expect(stdout).to.include('addRun: SUCCESS - the request data is {"suite_id":1,"name":"Custom run name","include_all":false}');
+				expect(stdout).to.include('addRun: SUCCESS - the response data is {"suite_id":1,"name":"Custom run name","include_all":false,"id":2}');
 				done();
 			});
 		});


### PR DESCRIPTION
Changes:
---
- [x] more unifrom logging accross the board for all of our helpers


Discsussion:
---
@PeterNgTr I think this PR is a valuable one since it'll give the user more chances to see what's wrong if anything happens in any helper, both error and success cases. You can see I have included stuff like `Success` and `Error` messages alongside helpers names to give our consumers a better insight into what's going wrong, in case that happens when they're trying to update their TR projects. 