### PR TITLE
Logs and logic improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,14 @@ module.exports = (config) => {
 		}
 	}
 
+	async function _getTestRun(runId) {
+		try {
+			await testrail.getRun(runId);
+		} catch (error) {
+			output.error(`Cannot get run due to ${error}`);
+		}
+	}
+
 	async function _addTestRun(projectId, suiteId, runName) {
 		try {
 			return testrail.addRun(projectId, { suite_id: suiteId, name: runName, include_all: false });
@@ -209,7 +217,11 @@ module.exports = (config) => {
 						runId = res.id;
 					}
 
-					await _updateTestRun(runId, ids);
+					// Do not update the run if it is part of a plan, but this has not been specified in the config
+					const runData = await _getTestRun(runId)
+					if (runData && runData.plan_id) {
+						await _updateTestRun(runId, ids);
+					}
 				} catch (error) {
 					output.error(error);
 				}

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ module.exports = (config) => {
 
 					// Do not update the run if it is part of a plan, but this has not been specified in the config
 					const runData = await _getTestRun(runId)
-					if (runData && runData.plan_id) {
+					if (runData && !runData.plan_id) {
 						await _updateTestRun(runId, ids);
 					}
 				} catch (error) {

--- a/lib/testrail.js
+++ b/lib/testrail.js
@@ -105,6 +105,18 @@ class TestRail {
 		}
 	}
 
+	async getRun(runId) {
+		try {
+			const res = await this.axios.get('get_run/' + runId);
+			output.log(`updateRun: SUCCESS - the request data is runId:${runId}`);
+			output.log(`updateRun: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
+			return res.data;
+		} catch (error) {
+			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
+			output.error(`updateRun: ERROR - cannot get run for runId:${runId} due to ${parsedError}`);
+		}
+	}
+
 	async getResultsForCase(runId, caseId) {
 		return this.axios.get(`get_results_for_case/${runId}/${caseId}`).then((res) => {
 			output.log(`getResultsForCase: SUCCESS - the response data is ${JSON.stringify(res.data)}`);

--- a/lib/testrail.js
+++ b/lib/testrail.js
@@ -39,7 +39,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`addPlan: ERROR - cannot get results projectId:${projectId} due to ${parsedError}`);
+			output.error(`addPlan: ERROR - cannot add plan to projectId:${projectId} due to ${parsedError}`);
 			output.error(`addPlan: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
@@ -52,7 +52,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`addPlanEntry: ERROR - cannot get results on planId:${planId} due to ${parsedError}`);
+			output.error(`addPlanEntry: ERROR - cannot add plan entry to planId:${planId} due to ${parsedError}`);
 			output.error(`addPlanEntry: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
@@ -64,7 +64,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`getSuites: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);
+			output.error(`getSuites: ERROR - cannot get suites for projectId:${projectId} due to ${parsedError}`);
 		}
 	}
 
@@ -75,7 +75,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`getConfigs: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);
+			output.error(`getConfigs: ERROR - cannot get configs for projectId:${projectId} due to ${parsedError}`);
 		}
 	}
 
@@ -87,7 +87,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`addRun: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);
+			output.error(`addRun: ERROR - cannot add run to projectId:${projectId} due to ${parsedError}`);
 			output.error(`addRun: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}
@@ -100,7 +100,7 @@ class TestRail {
 			return res.data;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
-			output.error(`updateRun: ERROR - cannot get results for runId:${runId} due to ${parsedError}`);
+			output.error(`updateRun: ERROR - cannot update run for runId:${runId} due to ${parsedError}`);
 			output.error(`updateRun: ERROR - request data was ${JSON.stringify(data)}`);
 		}
 	}

--- a/test/db.json
+++ b/test/db.json
@@ -2,6 +2,7 @@
   "get_configs": [],
   "add_run": [],
   "update_run": [],
+  "get_run": {},
   "add_results_for_cases": [],
   "get_cases": [{"id": "1"}, {"id": "2"}],
   "get_results_for_case": []

--- a/test/routes.json
+++ b/test/routes.json
@@ -3,6 +3,8 @@
   "/index.php?/api/v2/add_run/1": "/add_run/",
   "/index.php?/api/v2/update_run/1": "/update_run/",
   "/index.php?/api/v2/update_run/2": "/update_run/",
+  "/index.php?/api/v2/get_run/1": "/get_run/",
+  "/index.php?/api/v2/get_run/2": "/get_run/",
   "/index.php?/api/v2/add_results_for_cases/1": "/add_results_for_cases/",
   "/index.php?/api/v2/add_results_for_cases/2": "/add_results_for_cases/",
   "/index.php?/api/v2/get_cases/1&suite_id=1": "/get_cases/",


### PR DESCRIPTION
Changes:
---
Avoid running `updateRun` if this is indeed part of a test plan, but this has not been specified in the config:

Current error without the changes:
---
```
18:15:00  tests-runner | updateRun: ERROR - cannot get results for runId:6190 due to This operation is not allowed. The test run belongs to a test plan and cannot be edited independently.
18:15:00  tests-runner | updateRun: ERROR - request data was {"case_ids":["347755","347760","347608","347696"]}
```

GetRun TR API call response:
---
![image](https://user-images.githubusercontent.com/16047402/133136399-ddc6a5b0-8734-491f-9541-4700f598444d.png)
