### PR TITLE
res.data.cases instead of res.data in getCases

### DIFF
--- a/lib/testrail.js
+++ b/lib/testrail.js
@@ -24,7 +24,7 @@ class TestRail {
 		try {
 			const res = await this.axios.get(`get_cases/${projectId}&suite_id=${suiteId}`);
 			output.log(`getCases: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
-			return res.data;
+			return res.data.cases;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
 			output.error(`getCases: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);


### PR DESCRIPTION
getCases response doesn't consist only of cases array, but starts with the following info:

{
  "offset": 0,
  "limit": 250,
  "size": 123,
  "_links": { "next": null, "prev": null },
  "cases": [

therefore in checking the length of res in index.js results in undefined and test run results are not published to TestRail. After this fix, the results are published again, as the getCases function returns only the cases array.