### PR TITLE
Added possibility to specify own status id for pass/fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,16 +11,16 @@ const supportedHelpers = [
 	'Playwright',
 	'TestCafe'
 ];
+
 const defaultConfig = {
 	host: '',
 	user: '',
 	password: '',
-	enabled: false
-};
-
-const testCase = {
-	passed: { status_id: 1 },
-	failed: { status_id: 5 },
+	enabled: false,
+	testCase: {
+		passed: { status_id: 1 },
+		failed: { status_id: 5 },
+	}
 };
 
 let helper;
@@ -228,7 +228,12 @@ module.exports = (config) => {
 			}
 
 			passedTests.forEach(test => {
-				testCase.passed.comment = `Test case C${test.case_id} is PASSED.`;
+				const testCase = {
+					passed: {
+						comment: `Test case C${test.case_id} is PASSED.`,
+						status_id: config.testCase.passed.status_id
+					}
+				}
 				Object.assign(test, testCase.passed);
 			});
 
@@ -239,7 +244,12 @@ module.exports = (config) => {
 				} else {
 					errorString = errors[test.case_id];
 				}
-				testCase.failed.comment = `Test case C${test.case_id} is FAILED due to **${errorString}**`;
+				const testCase = {
+					failed: {
+						comment: `Test case C${test.case_id} is FAILED due to **${errorString}**`,
+						status_id: config.testCase.failed.status_id
+					}
+				}
 				Object.assign(test, testCase.failed);
 			});
 

--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,10 @@ plugins: {
       groupName: 'macos',
       configName: 'leopard'
     },
+    testCase: {
+		  passed: { status_id: 1 },
+		  failed: { status_id: 5 },
+	  }
     enabled: true
   }
 }
@@ -123,5 +127,6 @@ plugins: {
 - `plan - existingPlanId`: if you provide an existing plan ID, the new test run is added to that test plan. Otherwise, new test plan is created and new test run is added to that test plan.
 - `plan - name`: your desired plan name.
 - `plan - description`: your desired description to your test plan.
+- `testCase`: if you configured testrail to use custom test case statuses, you can override default status_id with yours. 
 - `configuration`: provide the created configuration group name - configuration name that you want to add to the test run. If you don't provide anything or wrong either group name or config name, there will be no configuration added to test run.
 - `debugLog`: show more logs for debugging purposes.


### PR DESCRIPTION
On current project we have own custom statuses for pass/fail when running autotests.

This PR adds possibility to specify custom status_id in config

![image](https://user-images.githubusercontent.com/3033972/135859999-cb594ade-40eb-4d8b-9ef4-7e3abc9a0dd0.png)
