### PR TITLE
return res.data.results in getResultsForCase

### DIFF
--- a/lib/testrail.js
+++ b/lib/testrail.js
@@ -120,7 +120,7 @@ class TestRail {
 	async getResultsForCase(runId, caseId) {
 		return this.axios.get(`get_results_for_case/${runId}/${caseId}`).then((res) => {
 			output.log(`getResultsForCase: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
-			return res.data;
+			return res.data.results;
 		}).catch(error => {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
 			output.error(`getResultsForCase: ERROR - cannot get results for caseId:${caseId} on runId:${runId} due to ${parsedError}`);


### PR DESCRIPTION
getResultsForCase response doesn't consist only of results array, but starts with the following info:

{
"offset": 0,
"limit": 250,
"size": 123,
"_links": { "next": null, "prev": null },
"results": [

therefore the `helper && testrail.addAttachmentToResult(res[0].id, attachments[test.case_id]);` code using getResultsForCase response in `res` variable will error, as `res[0]` is undefined, and accessing `id` property is not possible.