### PR TITLE
onlyRunIds option

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,8 +181,9 @@ module.exports = (config) => {
 					const data = {
 						suite_id: suiteId,
 						name: runName,
-						include_all: true,
+						include_all: !config.plan.onlyRunIds,
 						config_ids,
+						case_ids: ids,
 						runs: [{
 							include_all: false,
 							case_ids: ids,

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ module.exports = (config) => {
 					const data = {
 						suite_id: suiteId,
 						name: runName,
-						include_all: !config.plan.onlyRunIds,
+						include_all: !config.plan.onlyCaseIds,
 						config_ids,
 						case_ids: ids,
 						runs: [{

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ plugins: {
 - `plan - existingPlanId`: if you provide an existing plan ID, the new test run is added to that test plan. Otherwise, new test plan is created and new test run is added to that test plan.
 - `plan - name`: your desired plan name.
 - `plan - description`: your desired description to your test plan.
-- `plan - onlyRunIds` (Optional): if `true` it will consider only test cases that run while posting results to testrail
+- `plan - onlyCaseIds` (Optional): if `true` it will consider only test cases that actually run while posting results to testrail
 - `testCase`: if you configured testrail to use custom test case statuses, you can override default status_id with yours. 
 - `configuration`: provide the created configuration group name - configuration name that you want to add to the test run. If you don't provide anything or wrong either group name or config name, there will be no configuration added to test run.
 - `debugLog`: show more logs for debugging purposes.

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,9 @@ plugins: {
 - `plan - existingPlanId`: if you provide an existing plan ID, the new test run is added to that test plan. Otherwise, new test plan is created and new test run is added to that test plan.
 - `plan - name`: your desired plan name.
 - `plan - description`: your desired description to your test plan.
+- `plan - onlyRunIds` (Optional): if `true` it will consider only test cases that run while posting results to testrail
 - `testCase`: if you configured testrail to use custom test case statuses, you can override default status_id with yours. 
 - `configuration`: provide the created configuration group name - configuration name that you want to add to the test run. If you don't provide anything or wrong either group name or config name, there will be no configuration added to test run.
 - `debugLog`: show more logs for debugging purposes.
 - `closeTestRun`: by default test run is close afterwards.
+


### PR DESCRIPTION
resolve #67 

This PR adds option to not include all ids while creating test run within an existing plan, instead of that you can create a run with the test cases that actually run