### PR TITLE
Return re.data if res.data.cases is undefined

### DIFF
--- a/lib/testrail.js
+++ b/lib/testrail.js
@@ -25,27 +25,31 @@ class TestRail {
 		try {
 			const res = await this.axios.get(`get_cases/${projectId}&suite_id=${suiteId}`);
 			output.log(`getCases: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
-			let isLimit = false;
+			let isLimit = false
 			let offset = 250;
-			fullArr = res.data && res.data.cases;
-			//limit logic works only if we suspect that api call send back limited array === 250 cases
-			if(res.data.cases.length === offset){
-				isLimit = true;
-				while (isLimit === true) {
-					const restOffset = await this.axios.get(`get_cases/${projectId}&suite_id=${suiteId}&offset=${offset}`);
-					if (restOffset.data.cases != 0) {
-						restOffset.data.cases.forEach(item=> {
-							fullArr.push(item);
-						});
-					}
-					if (restOffset.data.cases.length < 250) {
-						isLimit = false;
-					} else {
-						offset = offset+250;
+			if (res.data.cases == undefined) {
+				return res.data
+			} else {
+				fullArr = res.data && res.data.cases;
+				//limit logic works only if we suspect that api call send back limited array === 250 cases
+				if(res.data.cases.length === offset){
+					isLimit = true;
+					while (isLimit === true) {
+						const restOffset = await this.axios.get(`get_cases/${projectId}&suite_id=${suiteId}&offset=${offset}`);
+						if (restOffset.data.cases != 0) {
+							restOffset.data.cases.forEach(item=> {
+								fullArr.push(item)
+							});
+						}
+						if (restOffset.data.cases.length < 250) {
+							isLimit = false;
+						} else {
+							offset = offset+250;
+						}
 					}
 				}
+				return fullArr;
 			}
-			return fullArr;
 		} catch (error) {
 			const parsedError = error && error.response && error.response.data ? error.response.data.error : error;
 			output.error(`getCases: ERROR - cannot get results for projectId:${projectId} due to ${parsedError}`);

--- a/lib/testrail.js
+++ b/lib/testrail.js
@@ -25,12 +25,12 @@ class TestRail {
 		try {
 			const res = await this.axios.get(`get_cases/${projectId}&suite_id=${suiteId}`);
 			output.log(`getCases: SUCCESS - the response data is ${JSON.stringify(res.data)}`);
-			let isLimit = false
-			let offset = 250;
 			if (res.data.cases == undefined) {
 				return res.data
 			} else {
-				fullArr = res.data && res.data.cases;
+				let isLimit = false
+				let offset = 250;
+				fullArr = res.data.cases;
 				//limit logic works only if we suspect that api call send back limited array === 250 cases
 				if(res.data.cases.length === offset){
 					isLimit = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-testrail",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "description": "CodeceptJS plugin for TestRail",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
We have been hitting issues since https://github.com/PeterNgTr/codeceptjs-testrail/commit/6fddcb73bd609d11af4b44fb8d0a71b63e22e6be - Previously we were relying on the code that would return `res.data`. The new code doesn't handle if res.data.cases is undefined i.e. 
```
16:06:33  tests-runner | Unhandled Rejection at: Promise Promise {
16:06:33  tests-runner |   <rejected> TypeError: Cannot read property 'length' of undefined
16:06:33  tests-runner |       at /tests/node_modules/codeceptjs-testrail/index.js:271:13
16:06:33  tests-runner |       at processTicksAndRejections (internal/process/task_queues.js:95:5),
16:06:33  tests-runner |   [Symbol(async_id_symbol)]: 722922,
16:06:33  tests-runner |   [Symbol(trigger_async_id_symbol)]: 722921,
16:06:33  tests-runner |   [Symbol(destroyed)]: { destroyed: false }
16:06:33  tests-runner | } reason: TypeError: Cannot read property 'length' of undefined
16:06:33  tests-runner |     at /tests/node_modules/codeceptjs-testrail/index.js:271:13
16:06:33  tests-runner |     at processTicksAndRejections (internal/process/task_queues.js:95:5)
16:06:33  tests-runner | [02] Worker Error: TypeError: Cannot read property 'length' of undefined
16:06:33  tests-runner |     at /tests/node_modules/codeceptjs-testrail/index.js:271:13
16:06:33  tests-runner |     at processTicksAndRejections (internal/process/task_queues.js:95:5)
16:06:33  tests-runner | [02] [INFO] All worker suites finished
```


This change updates the code to handle both return objects. 