### PR TITLE
fix: expose process.env.TESTRAIL_RUN_URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,6 +275,7 @@ module.exports = (config) => {
 						runId = config.runId;
 					} else {
 						const res = await _addTestRun(config.projectId, suiteId, runName);
+						process.env.TESTRAIL_RUN_URL = res.url;
 						runId = res.id;
 					}
 


### PR DESCRIPTION
expose `process.env.TESTRAIL_RUN_URL` so it would be accessible elsewhere.

closes #102 